### PR TITLE
Added authorize_with_ssl_client

### DIFF
--- a/lib/smart_proxy_openscap/openscap_api.rb
+++ b/lib/smart_proxy_openscap/openscap_api.rb
@@ -14,6 +14,7 @@ module Proxy::OpenSCAP
   class Api < ::Sinatra::Base
     include ::Proxy::Log
     helpers ::Proxy::Helpers
+    authorize_with_ssl_client
 
     put "/arf/:policy" do
       # first let's verify client's certificate


### PR DESCRIPTION
We have refactored develop proxy and extracted the SSL client cert handling
code. Please review. This is needed only if this plugin uses SSL client
certification verification. If not, please close it.